### PR TITLE
Fixed StringHandler#getString's array index out of bounds protection.

### DIFF
--- a/src/main/java/me/quadraboy/commander/structure/handler/StringHandler.java
+++ b/src/main/java/me/quadraboy/commander/structure/handler/StringHandler.java
@@ -12,7 +12,7 @@ public abstract class StringHandler {
     }
 
     public String getString(final int targetIndex) {
-        return (strings.length == targetIndex + 1) ? strings[targetIndex] : "";
+        return (targetIndex < strings.length) ? strings[targetIndex] : "";
     }
 
     public String[] getStringsFrom(final int fromIndex) {


### PR DESCRIPTION
The old check only passes if the index points to the last element of the arguments array. 

Corrected to passing if index is within the upper bounds of the array and throws error if it's in the negative because ~~I am lazy and also~~ at that point there's just logic errors and this should make it more convenient to debug.