### PR TITLE
Append the caught exception as cause parameter

### DIFF
--- a/src/main/java/me/quadraboy/commander/CommandRegistry.java
+++ b/src/main/java/me/quadraboy/commander/CommandRegistry.java
@@ -66,7 +66,7 @@ public class CommandRegistry {
                             if(status == Command.Status.FAILED) sender.sendMessage(formattedUsage);
 
                         } catch (Exception e) {
-                            throw new CommandException("An error occurred when running the Executor method: " + e);
+                            throw new CommandException("An error occurred when running the Executor method", e);
                         }
                         return true;
                     }
@@ -87,7 +87,7 @@ public class CommandRegistry {
 
                         if(method.getAnnotation(Suggester.class).sorted()) Collections.sort(suggestion.getCompletions());
                     } catch (Exception e) {
-                        throw new CommandException("An error occurred when running the Suggester method: " + e);
+                        throw new CommandException("An error occurred when running the Suggester method", e);
                     }
                 });
                 return suggestion.getCompletions();


### PR DESCRIPTION
Currently, when an error happens on execution, this happens:

<img width="1210" alt="Screenshot 2024-05-26 at 3 12 49 PM" src="https://github.com/QuadraBoy/commander/assets/69229995/4e081e89-7551-4bb6-b207-7295be489dc6">

Which doesn't exactly tell you anything. Therefore, I've changed it so it's more convenient for debugging. 